### PR TITLE
auc search card name fix

### DIFF
--- a/modules/auctions.js
+++ b/modules/auctions.js
@@ -36,7 +36,7 @@ function processRequest(user, args, channelID, callback) {
             info(user, args, channelID, callback);
             break;
         default:
-            if(command) args.push(command);
+            if(command) args.unshift(command);
             list(user, args, channelID, callback);
             break;
     }


### PR DESCRIPTION
push was making the first word get put in the last position so searching "devils dance" would search "dance devil"