### PR TITLE
Fix Snake-haired girl eval

### DIFF
--- a/modules/dbmanager.js
+++ b/modules/dbmanager.js
@@ -885,7 +885,6 @@ function eval(user, args, callback, isPromo) {
     if(args.includes('-multi'))
         return callback(utils.formatError(user, "Request error", "flag `-multi` is not valid for this request"));
 
-    isPromo = isPromo || args.filter(a => a.includes('-h')).length > 0;
     let ccollection = isPromo ? mongodb.collection('promocards') : mongodb.collection('cards');
 
     let query = utils.getRequestFromFiltersNoPrefix(args);


### PR DESCRIPTION
Bot no longer uses promo collection when `-h` is in any of the requests (the other fallback system for detecting when to use the promo collection is working fine, and it's not like the current one was set up to track the other promo cards anyways)