### PR TITLE
Add heapdump command to help debug memory usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const auctions = require('./modules/auctions.js');
 const collections = require('./modules/collections.js');
 const admin = require('./modules/admin.js');
 const guilds = require('./modules/guild.js');
+const heapdump = require("heapdump");
 
 var bot, curShard = 0, shards = 0;
 var cooldownList = [];
@@ -311,6 +312,21 @@ async function getCommand(user, channel, guild, message, event, callback) {
                     }
                 } else {
                     callback(user.username + ", 'award' is admin-only command");
+                }
+                return;
+            case 'heapdump':
+                if(dbManager.isAdmin(user.id)) {
+                    heapdump.writeSnapshot("./amusementclub-" + Date.now() + ".heapsnapshot", (err, filename) => {
+                        if (filename) {
+                            callback(`Finished writing heap snapshot to ${filename}`);
+                        }
+                        else {
+                            callback("Failed to write heap snapshot")
+                        }
+                    });
+                }
+                else {
+                    callback(user.username + ", 'heapdump' is admin-only command");
                 }
                 return;
             case 'lead':

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "js-levenshtein": "^1.1.2",
     "lodash": "^4.17.10",
     "mkdirp": "^0.5.1",
-    "mongodb": "^2.2.30"
+    "mongodb": "^2.2.30",
+    "heapdump": "^0.3.11"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When the bot is using a mediumishly high amount of memory (it takes memory to generate the heap dump so don't do it when you have none left), run `->heapdump` (admin only command) to freeze the bot in the name of heapdump generation, then open the resulting file with chrome/opera debug tools.  It might help us figure out what's using the most memory and if there's any easy optimizations we can make to use less memory.
Info on how to use the memory debugger available [here](https://developers.google.com/web/tools/chrome-devtools/memory-problems/heap-snapshots)