### PR TITLE
Easier init run of bot; Collections created on ayy update

### DIFF
--- a/modules/collections.js
+++ b/modules/collections.js
@@ -1,5 +1,5 @@
 module.exports = {
-    connect, processRequest, getCollections, parseCollection, getByID
+    connect, processRequest, getCollections, addCollection, parseCollection, getByID
 }
 
 const dbManager = require("./dbmanager.js");
@@ -97,6 +97,19 @@ function getCollections() {
             cache = c;
             resolve(c);
         });
+    });
+}
+
+function addCollection(col, special = false, compressed = false) {
+    return new Promise((resolve) => {
+        mongodb.collection('collections').insert({
+            id: col,
+            name: col,
+            origin: null,
+            aliases: [col],
+            special: special,
+            compressed: compressed
+        }).then(c => resolve(c));
     });
 }
 

--- a/modules/dbmanager.js
+++ b/modules/dbmanager.js
@@ -498,8 +498,20 @@ function sell(user, to, args, callback) {
 
 function newUser(user, nextCall, callback) {
     let collection = mongodb.collection('users');
+    let ccollection = mongodb.collection('cards');
     let scollection = mongodb.collection('system');
-    scollection.findOne({type: "dailycard"}).then(c => {
+    scollection.findOne({type: "dailycard"}).then(async c => {
+        if (!c) {
+            c = {
+                type: "dailycard",
+                timestamp: new Date(),
+                card: (await ccollection.aggregate([
+                    {"$match": {"level": 3}},
+                    {"$sample" : {"size": 1}}
+                ]).toArray())[0]
+            };
+            await scollection.insert(c);
+        }
         return collection.insert( { 
             discord_id: user.id,
             username: user.username,


### PR DESCRIPTION
1. Eliminates the need for amusement-api by adding the "dailycard" to the system table when needed. When running the bot for the first time, it is now much easier to get it running without encountering problems.
2. Running `ayy update` now creates collections for the new cards remotely added. 
3. Ayano commands (`ayy help`) have been added to modify collection data (name, origin, and aliases), so manual creation of collections to the database is no longer necessary.
4. New cards for existing collections will not create new collections or override existing collection data.