### PR TITLE
Auction finish time improvements

### DIFF
--- a/help/updates.json
+++ b/help/updates.json
@@ -1,5 +1,11 @@
 [
     {
+        "version": "1.13.0",
+        "changes": [
+            "Increased auction end-time accuracy"
+        ]
+    },
+    {
         "version": "1.12.9",
         "changes": [
             "Admin comands update",

--- a/modules/auctions.js
+++ b/modules/auctions.js
@@ -397,9 +397,7 @@ function getTimeUntilAucEnds(auc) {
     const minutes = Math.floor(base % 60);
     const seconds = Math.floor((base * 60) % 60);
 
-    return  hours > 0    ? `${hours}h ${minutes}m`  :
-            minutes > 0  ? `${minutes}m ${seconds}s`:
-            `${seconds}s`;
+    return  hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m ${seconds}s`;
 }
 
 async function generateBetterID() {

--- a/modules/auctions.js
+++ b/modules/auctions.js
@@ -388,17 +388,17 @@ function auctionToString(auc, userID) {
 
 function getTimeUntilAucEnds(auc) {
     const timeUntilEndMs = auc.date.setHours(auc.date.getHours() + 5) - new Date();
-    const base = timeUntilEndMs / (1000 * 60 * 60);
 
     if (timeUntilEndMs <= 0)
         return "0s";
     
-    const hours = Math.floor(base);
-    const minutes = Math.floor(base % 1 * 60);
-    const seconds = Math.floor(base % 1 * 60 % 1 * 60);
+    const base = timeUntilEndMs / (1000 * 60);
+    const hours = Math.floor(base / 60);
+    const minutes = Math.floor(base % 60);
+    const seconds = Math.floor((base * 60) % 60);
 
-    return  hours > 0 ? `${hours}h ${minutes}m`:
-            minutes > 0 > hours ? `${minutes}m ${seconds}s`:
+    return  hours > 0    ? `${hours}h ${minutes}m`  :
+            minutes > 0  ? `${minutes}m ${seconds}s`:
             `${seconds}s`;
 }
 

--- a/modules/auctions.js
+++ b/modules/auctions.js
@@ -151,7 +151,7 @@ async function bid(user, args, callback) {
         if(hidebid) msg += "Next required bid is hidden by hero effect.\n";
         else msg += "To remain in the auction, you should bid more than **" + getNextBid(auc) + "**🍅\n"
         msg += "Use `->auc bid " + auc.id + " [new bid]`\n";
-        msg += "This auction will end in **" + getTime(auc) + "**";
+        msg += "This auction will end in **" + getTimeUntilAucEnds(auc) + "**";
         sendDM(auc.lastbidder, utils.formatWarning(null, "Oh no!", msg));
     } else {
         auc.price = price;
@@ -159,7 +159,7 @@ async function bid(user, args, callback) {
         let msg = "A player has bid on your card **" + utils.getFullCard(auc.card)  + "** with a bid of **" + strprice + "**🍅\n";
 
         if(hidebid) msg += "The bid is hidden by hero effect.\n";
-        msg += "This auction will end in **" + getTime(auc) + "**";
+        msg += "This auction will end in **" + getTimeUntilAucEnds(auc) + "**";
         sendDM(auc.author, utils.formatInfo(null, "Yay!", msg));
     }
 
@@ -294,7 +294,7 @@ async function info(user, args, channelID, callback) {
         if(user.id == auc.lastbidder && !auc.finished) 
             resp += "You are currently leading in this auction\n";
         if(auc.finished) resp += "**This auction has finished**\n";
-        else resp += "Finishes in: **" + getTime(auc) + "**\n";
+        else resp += "Finishes in: **" + getTimeUntilAucEnds(auc) + "**\n";
 
         let emb = utils.formatInfo(null, "Information about auction", resp);
         emb.image = {url: dbManager.getCardURL(auc.card, false)};
@@ -379,28 +379,27 @@ function auctionToString(auc, userID) {
         else resp += "🔷";
     else if(userID == auc.lastbidder) resp += "🔸";
     else resp += "▪";
-    resp += "`[" + getTime(auc) + "] ";
+    resp += "`[" + getTimeUntilAucEnds(auc) + "] ";
     resp += "[" + auc.id + "] ";
     resp += "[" + getNextBid(auc) + "🍅]`  ";
     resp += "**" + utils.getFullCard(auc.card) + "**\n";
     return resp;
 }
 
-function getTime(auc) {
-    let hours = aucTime - utils.getHoursDifference(auc.date);
-    if (hours == 0)
+function getTimeUntilAucEnds(auc) {
+    const timeUntilEndMs = auc.date.setHours(auc.date.getHours() + 5) - new Date();
+    const base = timeUntilEndMs / (1000 * 60 * 60);
+
+    if (timeUntilEndMs <= 0)
         return "0s";
-    if(hours <= 1){
-        let mins = 60 - (utils.getMinutesDifference(auc.date) % 60);
-        if(mins <= 1){
-            let secs = 60 - (utils.getSecondsDifference(auc.date) % 60 % 60);
-            if(secs <= 1)
-                return "1s";
-            return secs + "s";
-        }
-        return mins + "m";
-    } else 
-        return hours + "h";
+    
+    const hours = Math.floor(base);
+    const minutes = Math.floor(base % 1 * 60);
+    const seconds = Math.floor(base % 1 * 60 % 1 * 60);
+
+    return  hours > 0 ? `${hours}h ${minutes}m`:
+            minutes > 0 > hours ? `${minutes}m ${seconds}s`:
+            `${seconds}s`;
 }
 
 async function generateBetterID() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amusement_club",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Discord Gacha Bot",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR allows players to more accurately track how much time is left until an auction will end. The bot will no longer heavily round times.

The bot will display times as follows:
- [0m 30s]
- [7m 44s]
- [1h 13m]