### PR TITLE
Transaction Auditing

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,7 +245,7 @@ async function getCommand(user, channel, guild, message, event, callback) {
             case 'transactions':
                 if(channelType == 1) botOnly(chanID);
                 else {
-                    transactions.processRequest(user, sb, cnt, (text) => {
+                    transactions.processRequest(user, chanID, sb, cnt, (text) => {
                         callback(text);
                     });
                 }


### PR DESCRIPTION
In a channel specified in settings/general.json (auditchannel), privileged users may view other players' transaction history by adding `audit [userID]` into the start of a transaction command. 
Examples:
->trans audit [userID]
->trans audit [userID] gets
This tool can be used to investigate bad behavior.