### PR TITLE
Improved Audit Tools

### DIFF
--- a/modules/auctions.js
+++ b/modules/auctions.js
@@ -170,12 +170,14 @@ async function bid(user, args, callback) {
         sendDM(auc.author, utils.formatInfo(null, "Yay!", msg));
     }
 
+    auc.bids.unshift({"bid": price, "bidder": user.id, "date": new Date()});
     await acollection.update({_id: auc._id}, {$set: {
         price: price, 
         lastbidder: user.id, 
         hidebid: hidebid, 
         timeshift: auc.timeshift,
-        date: auc.date
+        date: auc.date,
+        bids: auc.bids
     }});
 
     let p = utils.formatConfirm(user, "Bid placed", "you are now leading in auction for **" + utils.getFullCard(auc.card) + "**!");
@@ -278,7 +280,7 @@ async function sell(user, incArgs, channelID, callback) {
                         let aucID = await generateBetterID();
                         delete match.rating;
                         await acollection.insert({
-                            id: aucID, finished: false, date: new Date(), price: price, author: user.id, card: match
+                            id: aucID, finished: false, date: new Date(), price: price, author: user.id, card: match, bids:[]
                         });
 
                         callback(utils.formatConfirm(user, null, "you successfully put **" + utils.getFullCard(match) + "** on auction.\nYour auction ID `" + aucID + "`"));
@@ -350,7 +352,8 @@ async function checkAuctionList(client) {
         from: dbuser.username,
         from_id: dbuser.discord_id,
         status: "auction",
-        time: new Date()
+        time: new Date(),
+        bids: auc.bids
     }
 
     if(auc.lastbidder) {

--- a/modules/auctions.js
+++ b/modules/auctions.js
@@ -170,7 +170,7 @@ async function bid(user, args, callback) {
         sendDM(auc.author, utils.formatInfo(null, "Yay!", msg));
     }
 
-    auc.bids.unshift({"bid": price, "bidder": user.id, "date": new Date()});
+    auc.bids.unshift({"amount": price, "bidder": user.id, "date": new Date()});
     await acollection.update({_id: auc._id}, {$set: {
         price: price, 
         lastbidder: user.id, 

--- a/modules/localutils.js
+++ b/modules/localutils.js
@@ -173,7 +173,6 @@ function getRequestFromFiltersWithPrefix(args, prefix) {
             else if(el === "gif") query[prefix + 'animated'] = true;
             else if(el === "fav") query[prefix + 'fav'] = true;
             else if(el === "new") query[prefix + 'obtained'] = {$gt: date};
-            //else if(el === "rand") query[prefix + 'obtained'] = {$gt: date};
             else if(el === "frozen") {
                 var yesterday = new Date();
                 yesterday.setDate(yesterday.getDate() - 1);
@@ -246,7 +245,6 @@ function getRequestFromFiltersWithPrefix(args, prefix) {
         } catch(e) {}
     } 
 
-    console.log(JSON.stringify(query));
     return query;
 }
 

--- a/modules/localutils.js
+++ b/modules/localutils.js
@@ -12,6 +12,7 @@ module.exports = {
     parseToSeconds,
     msToTime,
     formatDate,
+    pad,
     HEXToVBColor,
     getSourceFormat,
     toTitleCase,

--- a/modules/localutils.js
+++ b/modules/localutils.js
@@ -11,6 +11,7 @@ module.exports = {
     getRegexString,
     parseToSeconds,
     msToTime,
+    formatDate,
     HEXToVBColor,
     getSourceFormat,
     toTitleCase,
@@ -171,6 +172,7 @@ function getRequestFromFiltersWithPrefix(args, prefix) {
             else if(el === "gif") query[prefix + 'animated'] = true;
             else if(el === "fav") query[prefix + 'fav'] = true;
             else if(el === "new") query[prefix + 'obtained'] = {$gt: date};
+            //else if(el === "rand") query[prefix + 'obtained'] = {$gt: date};
             else if(el === "frozen") {
                 var yesterday = new Date();
                 yesterday.setDate(yesterday.getDate() - 1);
@@ -243,6 +245,7 @@ function getRequestFromFiltersWithPrefix(args, prefix) {
         } catch(e) {}
     } 
 
+    console.log(JSON.stringify(query));
     return query;
 }
 
@@ -480,6 +483,25 @@ function diff(first, second, comparator) {
         secondOnly = secondOnly.concat(secondSorted.slice(i2));
     }
     return {firstOnly: firstOnly, secondOnly: secondOnly, both: both}
+}
+
+function formatDate (jsDateOb) {
+    let hr = jsDateOb.getHours();
+    let ampm = "am";
+    if (hr > 12) {
+        hr -= 12;
+        ampm = "pm";
+    }
+    let min = pad(jsDateOb.getMinutes(), 2);
+    return hr +":"+ min + " "+ ampm +" "+ jsDateOb.getDate() +"/"+ jsDateOb.getMonth() 
+        +"/"+ jsDateOb.getFullYear();
+}
+
+// Pad input "n" on the left with "width" number of "padChar" characters.
+function pad(n, width, padChar) {
+    padChar = padChar || '0';
+    n = n + '';
+    return n.length >= width ? n : new Array(width - n.length + 1).join(padChar) + n;
 }
 
 // db.getCollection('users').aggregate([

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -32,6 +32,7 @@ function processRequest(user, chanID, cmd, args, callback) {
             if(!parse.id)
                 return callback(utils.formatError(null, null, "please provide user ID"));
             targetUserID = parse.id;
+            req = args.shift();
         }
     }
 
@@ -53,6 +54,9 @@ function processRequest(user, chanID, cmd, args, callback) {
             break;
         case "info":
             info(user, targetUserID, auditMode, args, callback);
+            break;
+        case "audit":
+            callback(utils.formatWarning(user, null, "you cannot do that here."));
             break;
         default:
             all(user, targetUserID, auditMode, callback);
@@ -137,7 +141,7 @@ function gets(user, targetUserID, auditMode, callback) {
 
         let resp = formatTransactions(res, targetUserID);
         if ( auditMode ) resp = "(for <@"+ targetUserID +">)\n"+ resp;
-        callback(utils.formatInfo(null, "Recent transactions"+ auditResp, resp));
+        callback(utils.formatInfo(null, "Recent transactions", resp));
     });
 }
 
@@ -148,7 +152,7 @@ function sends(user, targetUserID, auditMode, callback) {
         
         let resp = formatTransactions(res, targetUserID);
         if ( auditMode ) resp = "(for <@"+ targetUserID +">)\n"+ resp;
-        callback(utils.formatInfo(null, "Recent transactions"+ auditResp, resp));
+        callback(utils.formatInfo(null, "Recent transactions", resp));
     });
 }
 
@@ -168,9 +172,8 @@ function all(user, targetUserID, auditMode, callback) {
             return callback(utils.formatWarning(user, null, "can't find recent transactions."));
 
         let resp = formatTransactions(res, targetUserID);
-        let auditResp = "";
         if ( auditMode ) resp = "(for <@"+ targetUserID +">)\n"+ resp;
-        callback(utils.formatInfo(null, "Recent transactions"+ auditResp, resp));
+        callback(utils.formatInfo(null, "Recent transactions", resp));
     });
 }
 

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -32,8 +32,6 @@ function processRequest(user, chanID, cmd, args, callback) {
             if(!parse.id)
                 return callback(utils.formatError(null, null, "please provide user ID"));
             targetUserID = parse.id;
-            //targetUserID = args.shift();
-            //req = args.shift();
         }
     }
 
@@ -138,7 +136,8 @@ function gets(user, targetUserID, auditMode, callback) {
             return callback(utils.formatWarning(user, null, "can't find recent transactions recieved."));
 
         let resp = formatTransactions(res, targetUserID);
-        callback(utils.formatInfo(null, "Recent transactions", resp));
+        if ( auditMode ) resp = "(for <@"+ targetUserID +">)\n"+ resp;
+        callback(utils.formatInfo(null, "Recent transactions"+ auditResp, resp));
     });
 }
 
@@ -148,7 +147,8 @@ function sends(user, targetUserID, auditMode, callback) {
             return callback(utils.formatWarning(user, null, "can't find recent transactions sent."));
         
         let resp = formatTransactions(res, targetUserID);
-        callback(utils.formatInfo(null, "Recent transactions", resp));
+        if ( auditMode ) resp = "(for <@"+ targetUserID +">)\n"+ resp;
+        callback(utils.formatInfo(null, "Recent transactions"+ auditResp, resp));
     });
 }
 

--- a/modules/transactions.js
+++ b/modules/transactions.js
@@ -125,7 +125,7 @@ async function info(user, targetUserID, auditMode, args, callback) {
         resp += "Bids ("+ transaction.bids.length +", newest first):\n";
         for(let bid of transaction.bids) {
             let date = new Date(bid.date);
-            resp += bid.bid +"🍅: <@"+ bid.bidder +"> @ "+ utils.formatDate(date) +"\n";
+            resp += bid.amount +"🍅: <@"+ bid.bidder +"> @ "+ utils.formatDate(date) +"\n";
         }
     }
 


### PR DESCRIPTION
- Add bid history into auctions 
- Display bid history for '->trans info' in auditchannel.
- Remove 'audit [user]' parametr from '->trans info' in auditchannel.
- Show discord IDs on '->trans info' in auditchannel
- Mention targetUser at start of '->trans' output in auditchannel
- Accept either a discord ID or a user mention as user specification after '->trans audit'