### PR TITLE
Added debugging output for claims edge case.

### DIFF
--- a/modules/dbmanager.js
+++ b/modules/dbmanager.js
@@ -196,8 +196,9 @@ async function claim(user, guild, channelID, arg, callback) {
             } else {
                 query[0].$match.collection = collections.getRandom().id;
             }
-            //console.log(JSON.stringify(query));
             let cardRes = await collection.aggregate(query).toArray();
+            if ( cardRes.length == 0 )
+                client.sendMessage({"to":settings.logchannel, "message":`Card claim query returned empty result: ${JSON.stringify(query)}`});
             res.push(cardRes[0]);
             remainingAmount--;
         } // end card-claiming loop


### PR DESCRIPTION
I suspect the recent reports of people not receiving claims is an adge
case where the query returns no cards. I added an if statement and a
print-out to the log channel that will say, "Card claim query returned
empty result" and then print the query.