### PR TITLE
Added card query element `.`, and updated claim boosts

### DIFF
--- a/help/modules.json
+++ b/help/modules.json
@@ -683,6 +683,10 @@
             {
                 "title": "->boost removecards [boost_id] [card_query]",
                 "description": "Removes cards from the specified boost."
+            },
+            {
+                "title": "->boost listcards [boost_id]",
+                "description": "Shows a list of all cards included in the specified boost."
             }
         ]
     }

--- a/modules/auctions.js
+++ b/modules/auctions.js
@@ -216,6 +216,8 @@ async function sell(user, incArgs, channelID, callback) {
         return callback("**" + user.username + "**, please specify card query and price seperated by `,`\n"
             + "Or do not specify price to use eval");
 
+    if ( args[0] == "." )
+        args[0] = utils.getCardArgs(await dbManager.getLastQueriedCard(user)).join(' ');
     let query = utils.getRequestFromFilters(args[0].split(' '));
     dbManager.getUserCards(user.id, query).toArray((err, objs) => {
         if(!objs || !objs[0]) 
@@ -232,6 +234,7 @@ async function sell(user, incArgs, channelID, callback) {
 
         let match = query['cards.name'] ? dbManager.getBestCardSorted(cards, query['cards.name'])[0] : cards[0];
         if(!match) return callback(utils.formatError(user, "Can't find card", "can't find card matching that request"));
+        dbManager.setLastQueriedCard(user,match);
         if (match.fav && match.amount == 1) 
             return callback(utils.formatError(user, null, "you can't sell favorite card."
                 + " To remove from favorites use `->fav remove [card query]`"));

--- a/modules/dbmanager.js
+++ b/modules/dbmanager.js
@@ -177,14 +177,14 @@ async function claim(user, guild, channelID, arg, callback) {
         while ( remainingAmount > 0 ) {
             let randomNum = Math.random();
             query[0].$match = {}; // reset the match query for each card
-            if (guild && guild.lock && !any) {
+            if ( boost && utils.randomChance(boost.chance) ) {
+                query[0].$match.boost = boost.id;
+            } else if (guild && guild.lock && !any) {
                 query[0].$match.collection = guild.lock;
                 query[0].$match.craft = {$in: [null, false]};
             } else if (settings.lockChannel && channelID == settings.lockChannel && dailyCol) {
                 query[0].$match.collection = dailyCol;
                 query[0].$match.craft = {$in: [null, false]};
-            } else if ( boost && utils.randomChance(boost.chance) ) {
-                query[0].$match.boost = boost.id;
             } else if ( randomNum < 0.005 ) {
                 query[0].$match.collection = "special";
                 // note: if you want to add another random condition,

--- a/modules/dbmanager.js
+++ b/modules/dbmanager.js
@@ -5,7 +5,8 @@ module.exports = {
     leaderboard, difference, dynamicSort, countCardLevels, getCardValue,
     getCardFile, getDefaultChannel, isAdmin, needsCards, getCardURL,
     removeCardFromUser, addCardToUser, eval, whohas, block, fav, track, getDB,
-    pushCard, pullCard, getCard, getCardDbColName, removeCardRatingFromAve
+    pushCard, pullCard, getCard, getCardDbColName, removeCardRatingFromAve,
+    getLastQueriedCard, setLastQueriedCard
 }
 
 var MongoClient = require('mongodb').MongoClient;
@@ -205,6 +206,7 @@ async function claim(user, guild, channelID, arg, callback) {
         //console.log(JSON.stringify(res));
 
         res.sort(dynamicSort('-level'));
+        setLastQueriedCard(user,res[0]);
 
         let phrase = "**" + user.username + "**, you got";
         if(amount == 1) {
@@ -426,7 +428,9 @@ function getQuests(user, callback) {
     });
 }
 
-function getCards(user, args, callback) {
+async function getCards(user, args, callback) {
+    if ( args[0] == "." )
+        args = utils.getCardArgs(await getLastQueriedCard(user));
     let query = utils.getRequestFromFilters(args);
     getUserCards(user.id, query).toArray((err, objs) => {
         if(!objs || !objs[0]) 
@@ -435,18 +439,22 @@ function getCards(user, args, callback) {
         let cards = objs[0].cards;
         if(args.includes('>date'))
             cards = cards.reverse();
+        
+        setLastQueriedCard(user,cards[0]);
 
         callback(cards, true);
     });
 }
 
-function rate(user, rating, args, callback) {
+async function rate(user, rating, args, callback) {
     if(!args) return callback(utils.formatError(user, null, "please specify card query"));
     if(typeof(rating) != "number" || isNaN(rating)|| rating < 1 || rating > 10) {
         return callback(utils.formatError(user, null, "please specify a rating between 1 and 10 before the card query"));
     }
 
     rating = Math.round(rating);
+    if ( args[0] == "." )
+        args = utils.getCardArgs(await getLastQueriedCard(user));
     let query1 = utils.getRequestFromFilters(args);
     getUserCards(user.id, query1).toArray((err, objs) => {
         if(!objs[0]) {
@@ -454,6 +462,7 @@ function rate(user, rating, args, callback) {
                 "can't find card matching that request"));
         }
         let cards = objs[0].cards;
+        setLastQueriedCard(user,cards[0]);
         let match = query1['cards.name']? getBestCardSorted(cards, query1['cards.name'])[0] : cards[0];
         if(!match) {
             return callback(utils.formatError(user, "Can't find card", 
@@ -515,8 +524,10 @@ function rate(user, rating, args, callback) {
     });
 }
 
-function summon(user, args, callback) {
+async function summon(user, args, callback) {
     if(!args) return callback("**" + user.username + "**, please specify card query");
+    if ( args[0] == "." )
+        args = utils.getCardArgs(await getLastQueriedCard(user));
     let query = utils.getRequestFromFilters(args);
     getUserCards(user.id, query).toArray((err, objs) => {
         if(!objs || !objs[0]) return callback(utils.formatError(user, "Can't find card", "can't find card matching that request"));
@@ -526,6 +537,7 @@ function summon(user, args, callback) {
         let match = query['cards.name']? getBestCardSorted(cards, query['cards.name'])[0] : getRandomCard(cards);
         if(!match) return callback(utils.formatError(user, "Can't find card", "can't find card matching that request"));
 
+        setLastQueriedCard(user,match);
         let alert = "**" + user.username + "** summons ";
 
         if(match.animated && match.imgur) {
@@ -548,11 +560,15 @@ function summon(user, args, callback) {
 
 async function getCardInfo(user, args, callback) {
     if(!args) return callback("**" + user.username + "**, please specify card query");
+    if ( args[0] == "." )
+        args = utils.getCardArgs(await getLastQueriedCard(user));
     let query = utils.getRequestFromFiltersNoPrefix(args);
 
     let card = await getCard(query);
         
         if(!card) return callback(utils.formatError(user, "Can't find card", "can't find card matching that request"));
+        
+        setLastQueriedCard(user,card);
 
         getCardValue(card, card, val => {
             let col = collections.parseCollection(card.collection)[0];
@@ -812,7 +828,7 @@ function award(uID, amout, callback) {
 
 //{'cards.name':/Holy_Qua/},{$set:{'cards.$.name':'holy_quaternity'}}
 
-function difference(discUser, parse, callback) {
+async function difference(discUser, parse, callback) {
     let targetID = parse.id;
     let args = parse.input;
     if(discUser.id == targetID) 
@@ -820,6 +836,8 @@ function difference(discUser, parse, callback) {
 
     if(!targetID) return;
 
+    if ( args[0] == "." )
+        args = utils.getCardArgs(await getLastQueriedCard(discUser));
     let query = utils.getRequestFromFilters(args);
     getUserCards(discUser.id, {}).toArray((err, objs) => {
         let cardsU1 = (objs && objs[0])? objs[0].cards : [];
@@ -847,13 +865,15 @@ function difference(discUser, parse, callback) {
     });
 }
 
-function eval(user, args, callback, isPromo) {
+async function eval(user, args, callback, isPromo) {
     if(!args[0]) return;
     if(args.includes('-multi'))
         return callback(utils.formatError(user, "Request error", "flag `-multi` is not valid for this request"));
 
     let ccollection = isPromo ? mongodb.collection('promocards') : mongodb.collection('cards');
 
+    if ( args[0] == "." )
+        args = utils.getCardArgs(await getLastQueriedCard(user));
     let query = utils.getRequestFromFiltersNoPrefix(args);
     ccollection.find(query).toArray((err, res) => {
         let match = query.name? getBestCardSorted(res, query.name)[0] : res[0];
@@ -861,6 +881,7 @@ function eval(user, args, callback, isPromo) {
             if (!isPromo) return eval(user, args, callback, true);
             else          return callback(utils.formatError(user, null, "no cards found that match your request"));
         }
+        setLastQueriedCard(user,match);
         getCardValue(match, match, price => {
             let name = utils.getFullCard(match);
             if(price == 0) callback(utils.formatInfo(user, null, "impossible to evaluate **" + name + "** since nobody has it"));
@@ -916,9 +937,11 @@ function removeCard(target, collection) {
     }
 }
 
-function doesUserHave(user, tgID, args, callback) {
+async function doesUserHave(user, tgID, args, callback) {
     if(!tgID) return;
 
+    if ( args[0] == "." )
+        args = utils.getCardArgs(await getLastQueriedCard(user));
     let query = utils.getRequestFromFilters(args);
     getUserCards(tgID, query).toArray((err, objs) => {
         if(!objs[0]) 
@@ -927,6 +950,7 @@ function doesUserHave(user, tgID, args, callback) {
         let cards = objs[0].cards;
         let match = query['cards.name']? getBestCardSorted(cards, query['cards.name'])[0] : cards[0];
         if(!match) return callback(utils.formatError(user, "Can't find card", "can't find card matching that request"));
+        setLastQueriedCard(user,match);
 
         let cardname = utils.toTitleCase(match.name.replace(/_/g, " "));
         if(match.fav == true)
@@ -970,8 +994,10 @@ function needsCards(user, args, callback) {
     });
 }
 
-function whohas(user, guild, args, callback) {
+async function whohas(user, guild, args, callback) {
     let ucollection = mongodb.collection('users');
+    if ( args[0] == "." )
+        args = utils.getCardArgs(await getLastQueriedCard(user));
     let query = utils.getRequestFromFiltersNoPrefix(args);
     ucollection.find(
         {"cards":{"$elemMatch":query}}
@@ -1007,7 +1033,7 @@ function whohas(user, guild, args, callback) {
     });  
 }
 
-function fav(user, args, callback) {
+async function fav(user, args, callback) {
     // Check for required params.
     if(!args || args.length == 0) return callback("**" + user.username + "**, please specify card query");
     let chanID = args[0];
@@ -1021,8 +1047,10 @@ function fav(user, args, callback) {
     if (remove && args.length > 0 && args[0] == 'all') all = true;
 
     // Find the cards.
+    if ( args[0] == "." )
+        args = utils.getCardArgs(await getLastQueriedCard(user));
     let query1 = utils.getRequestFromFilters(args);
-    getUserCards(user.id, query1).toArray((err, objs) => {
+    getUserCards(user.id, query1).toArray(async function(err, objs) {
         if(!objs[0]) {
             return callback(utils.formatError(user, "Can't find card", 
                 "can't find card matching that request"));
@@ -1069,6 +1097,7 @@ function fav(user, args, callback) {
                         "can't find card matching that request"));
                 }
             }
+            await setLastQueriedCard(user,match);
             objIds.push(''+match["_id"]);
             matchCount=1;
             fav2(user, objIds, remove, all, callback, match);
@@ -1489,3 +1518,28 @@ async function removeCardRatingFromAve(userCard) {
     return;
 }
 
+async function getLastQueriedCard(user) {
+    let card = false;
+    let userdat = await mongodb.collection('users').findOne(
+            {"discord_id": user.id},
+            {"lastQueriedCard": 1});
+    if ( userdat && userdat.lastQueriedCard ) {
+        card = userdat.lastQueriedCard;
+        //console.log("Got lastQueriedCard: "+ JSON.stringify(card));
+    }
+    return card;
+}
+
+async function setLastQueriedCard(user,card) {
+    let lastQuery = {};
+    lastQuery.name = card['name'];
+    lastQuery.level = card['level'];
+    lastQuery.collection = card['collection'];
+    mongodb.collection('users').update({"discord_id":user.id}, {$set:{"lastQueriedCard":lastQuery}})
+        .then(function(){
+            //console.log("lastQueriedCard for user "+ user.username +" ("+ user.id +") updated to:\n"+ JSON.stringify(lastQuery));
+        }).catch(function(err) {
+            console.log("Problem updating lastQueriedCard for user "+ user.username +" ("+ user.id +") to:\n"+ JSON.stringify(lastQuery));
+            console.log(err);
+        })
+}

--- a/modules/forge.js
+++ b/modules/forge.js
@@ -67,6 +67,7 @@ function getInfo(user, name, callback, image = false) {
 }
 
 async function craftCard(user, args, callback) {
+    // Note: "user" here, is the DB doc, not the discord user object.
     var cards = args.join(' ').split(/\s*,\s*/g);
     if(!cards || cards.length < 2)
         return callback("Minimum **2** cards or items required for forge\nDon't forget to put `,` between names"
@@ -81,6 +82,8 @@ async function craftCard(user, args, callback) {
             name = cards[i].substr(1); 
 
         let filters = name.split(" ");
+        if ( filters[0] == "." )
+            filters = utils.getCardArgs(user.lastQueriedCard);
         let query = utils.getRequestFromFilters(filters);
         let userCards = await dbManager.getUserCards(user.discord_id, query).toArray();
         let card;
@@ -243,6 +246,7 @@ function craftOrdinary(user, cards, callback) {
         ).then(u => { 
             //if(bonus[0] > 0) m += "\nAdded " + bonus[0] + "🍅 Tomatoes from card effect";
             callback(m);
+            dbManager.setLastQueriedCard({"id":user.discord_id},c);
         }).catch(e => {logger.error(e)});
     });
 }

--- a/modules/localutils.js
+++ b/modules/localutils.js
@@ -37,6 +37,7 @@ module.exports = {
     getRequestFromFiltersWithPrefix,
     getUserID,
     getRatio,
+    getCardArgs,
     getCardQuery,
     generateRandomId,
     generateNextId,
@@ -164,7 +165,7 @@ function getRequestFromFiltersWithPrefix(args, prefix) {
 
     //console.log(args);
     if(!args || args.length == 0) return query;
-    args.forEach(element => {
+    args.forEach(function(element) {
         element = element.trim();
         if(isInt(element) && parseInt(element) <= 5 && parseInt(element) > 0)
             levelInclude.push(parseInt(element));
@@ -535,6 +536,19 @@ function obj_array_search(array, target_val, target_key)
     return false;
 }
 
+// Given a card object, returns an array of arguments, such as would be
+// input by the user for a card query and used as input for 
+// getRequestFromFiltersWithPrefix
+function getCardArgs(card) {
+    args = [];
+    if ( !card )
+        return args;
+    args.push(card.name);
+    args.push('-'+ card.collection);
+    args.push(''+ card.level);
+    //console.log('getCardArgs is returning: '+ JSON.stringify(args));
+    return args;
+}
 
 // db.getCollection('users').aggregate([
 // {"$match":{"discord_id":"218871036962275338"}},

--- a/modules/sell.js
+++ b/modules/sell.js
@@ -58,6 +58,8 @@ async function processRequest(user, args, guild, channelID, callback) {
         transaction.guild_id = guild.id;
     }
 
+    if ( parse.input == "." )
+        parse.input = utils.getCardArgs(await dbmanager.getLastQueriedCard(user));
     let query = utils.getRequestFromFilters(parse.input);
 
     let objs = await dbmanager.getUserCards(user.id, query).toArray();
@@ -74,6 +76,7 @@ async function processRequest(user, args, guild, channelID, callback) {
 
     let match = query['cards.name'] ? dbmanager.getBestCardSorted(cards, query['cards.name'])[0] : cards[0];
     if(!match) return callback(utils.formatError(user, "Can't find cards", "can't find any card matching that request"));
+    dbmanager.setLastQueriedCard(user,match);
 
     if (match.fav && match.amount == 1) 
         return callback(utils.formatError(user, null, "you can't sell favorite card."


### PR DESCRIPTION
Anytime the player queries or receives a card, it gets cached in their user doc in the database as lastQueriedCard, and can be referenced by the user with a "."
Ex: `->summon .` summons lastQueriedCard 

Boosts can now be used on locked servers and channels.
Added boost command `->boost listcards [boost_id]`