### PR TITLE
patched: claim bug

### DIFF
--- a/modules/dbmanager.js
+++ b/modules/dbmanager.js
@@ -244,8 +244,9 @@ async function claim(user, guild, channelID, arg, callback) {
         }
 
         if(!dbUser.cards) dbUser.cards = [];
-        //res.map(r => dbUser.cards = addCardToUser(dbUser.cards, r));
-        res.map(r => pushCard(user.id, r));
+        for ( r of res ) {
+            await pushCard(user.id, r)
+        }
 
         dbUser.dailystats.claim += amount;
         heroes.addXP(dbUser, .5 * amount);


### PR DESCRIPTION
If a user claimed the same card twice in one claim, both copies would
get added to their cards as new cards rather than incrementing the
amount. This was because the array map function was rapid-firing off the
addCard requests without waiting for each to complete.