### PR TITLE
Fixed auc bid edge case

### DIFF
--- a/modules/auctions.js
+++ b/modules/auctions.js
@@ -97,7 +97,7 @@ async function list(user, args, channelID, callback) {
 }
 
 async function bid(user, args, callback) {
-    if(!args)
+    if(!args || args.length <1)
         return callback("**" + user.username + "**, please specify auction ID");
 
     if(args[1] && !utils.isInt(args[1]))


### PR DESCRIPTION
If someone sent `->auc bid`, then args was still evaluating to true, so
I added a check that args.length couldnt be less than 1.